### PR TITLE
Version 0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ desired URL structures and route actions without modifying any `.htaccess` files
 
 # Features
 * Dynamically choose page content based on URL
+* Great for improving SEO for your site by having informative site URLs
 * Easily create error pages for specific page types
-* Pull together functionality from other plugins and display your own page content
+* Conjoin functionality from other plugins and display your own page content
 * Create front page routes for your own plugins
 * Available in English, Italian, French, German and Russian
+* Works with and without [Fancy/Pretty URLS](http://get-simple.info/wiki/how_to:website_settings) enabled (v0.3+)
 
 # Screenshots
 ![screenshot of admin panel](https://cloud.githubusercontent.com/assets/4363863/14022767/31a5b174-f1d9-11e5-9d55-d69679ef82bd.png)
@@ -34,11 +36,16 @@ Check out the [wiki](https://github.com/lokothodida/gs-front-router/wiki) for mo
 * [Catalog (i18n Special Pages)](https://github.com/lokothodida/gs-front-router/wiki/Catalog-(i18n-Special-Pages)-Example)
 * [File listing](https://github.com/lokothodida/gs-front-router/wiki/File-Listing-Example)
 
+More examples in the [wiki](https://github.com/lokothodida/gs-front-router/wiki).
+
 # Wiki
-Full examples and documentation are available on the [wiki](https://github.com/lokothodida/gs-front-router/wiki). Contributions are welcome.
+Documentation, API, tutorials and contribution guidelines are all available on the [wiki](https://github.com/lokothodida/gs-front-router/wiki). Contributions are welcome.
 
 # License
 GetSimple Front Router is licensed under [MIT](http://www.opensource.org/licenses/MIT).
+
+# Contributers
+* [dimayakovlev](https://github.com/dimayakovlev) - Russian translation
 
 # Copyright
 All rights reserved.

--- a/front_router.php
+++ b/front_router.php
@@ -20,7 +20,7 @@ call_user_func(function() {
   call_user_func_array('register_plugin', array(
     'id'      => ID,
     'name'    => i18n_r('PLUGIN_NAME'),
-    'version' => '0.2',
+    'version' => '0.3',
     'author'  => 'Lawrence Okoth-Odida',
     'url'     => 'https://github.com/lokothodida',
     'desc'    => i18n_r('PLUGIN_DESC'),

--- a/front_router/php/functions.php
+++ b/front_router/php/functions.php
@@ -141,7 +141,8 @@ function executeRoutes() {
   foreach ($routes as $route => $callback) {
     // http://upshots.org/php/php-seriously-simple-router
     // Turn the route string into a valid regex
-    $pattern = '/^' . str_replace('/', '\/', $route) . '$/';
+    $suffix = '(\/*)';
+    $pattern = '/^' . str_replace('/', '\/', $route) . $suffix . '$/';
 
     // If the pattern matches, run the callback and pass in the parameters
     $match = @preg_match($pattern, $url, $params);

--- a/front_router/php/functions.php
+++ b/front_router/php/functions.php
@@ -185,10 +185,17 @@ function executeRoutes() {
   //return $data_index;
 }
 
+// Gets the root URL
+function getRootURL() {
+  $pretty  = (string) $GLOBALS['PRETTYURLS'];
+  $root    = $GLOBALS['SITEURL'] . (empty($pretty) ? 'index.php' : null);
+  return $root;
+}
+
 // Get URL relative to the domain
 function getRelativeURL() {
   $pretty  = (string) $GLOBALS['PRETTYURLS'];
-  $root    = $GLOBALS['SITEURL'] . (empty($pretty) ? 'index.php?id=' : null);
+  $root    = getRootURL() . (empty($pretty) ? '?id=' : null);
 
   return getURL($root);
 }

--- a/front_router/php/functions.php
+++ b/front_router/php/functions.php
@@ -141,8 +141,7 @@ function executeRoutes() {
   foreach ($routes as $route => $callback) {
     // http://upshots.org/php/php-seriously-simple-router
     // Turn the route string into a valid regex
-    $suffix = '(\/*)';
-    $pattern = '/^' . str_replace('/', '\/', $route) . $suffix . '$/';
+    $pattern = '/^' . str_replace('/', '\/', $route) . '$/';
 
     // If the pattern matches, run the callback and pass in the parameters
     $match = @preg_match($pattern, $url, $params);
@@ -210,5 +209,13 @@ function getURL($root = false) {
   $url = strstr($url, '//');
   $root = $root ? strstr($root, '//') : '';
 
-  return str_replace($root, '', $url);
+  // Shave off the root
+  $url = str_replace($root, '', $url);
+
+  // Shave off trailing slashes and double slashes
+  $url = ltrim($url, '/');
+  $url = rtrim($url, '/');
+  $url = preg_replace('~/+~', '/', $url); // http://stackoverflow.com/questions/2217759/regular-expression-replace-multiple-slashes-with-only-one
+
+  return $url;
 }

--- a/front_router/php/functions.php
+++ b/front_router/php/functions.php
@@ -187,7 +187,10 @@ function executeRoutes() {
 
 // Get URL relative to the domain
 function getRelativeURL() {
-  return getURL((string) $GLOBALS['SITEURL']);
+  $pretty  = (string) $GLOBALS['PRETTYURLS'];
+  $root    = $GLOBALS['SITEURL'] . (empty($pretty) ? 'index.php?id=' : null);
+
+  return getURL($root);
 }
 
 // Get the full URL


### PR DESCRIPTION
- Allow routing to work on non-pretty URLs (i.e. `index.php?id=some/route/here` if pretty URLs are disabled, `some/route/here` if enabled)
- Make routes less brittle on forward slashes (i.e. `///some/////route//here///` and `some/route/here` are equivalent.
