### PR TITLE
Add Feature: News Example Plugin

### DIFF
--- a/front_router/examples/news.php
+++ b/front_router/examples/news.php
@@ -6,6 +6,16 @@
  *  - Have I18N Special Pages installed
  *  - Have I18N Search installed
  *  - Have a special page called "News" created
+ *
+ * Once you have created some articles, go to:
+ *   /news/ to see the main page (lists all news articles)
+ *   /news/yyyy/ to see articles created in the year yyyy
+ *   /news/yyyy/mm/ to see articles created in the month mm of year yyyy
+ *   /news/yyyy/mm/dd/slug.html to see article with slug created yyyy/mm/dd
+ *
+ * If any page is suffixed with a language parameter (e.g. ?setlang=de), then
+ * that page will be shown with the language option restricted (e.g. listing
+ * only articles published in that language).
  */
 register_plugin(
   basename(__FILE__, '.php'),
@@ -39,7 +49,7 @@ add_action('front-route', 'addFrontRoute', array(
 
 // Article
 add_action('front-route', 'addFrontRoute', array(
-  'news/([0-9]{4})/([0-9]{2})/([0-9]{2})/([a-z0-9-]+)',
+  'news/([0-9]{4})/([0-9]{2})/([0-9]{2})/([a-z0-9-]+).html',
   'FrontRouterExampleI18NNews::articleRoute'
 ));
 
@@ -47,12 +57,14 @@ add_action('front-route', 'addFrontRoute', array(
 add_action('pages-sidebar', 'createSideMenu', array('i18n_specialpages&pages&special=news', 'Manage News'));
 
 /**
+ * Class for routing and displaying the news pages
+ *
  * @package FrontRouter
  * @subpackage ExampleI18NNews
  */
 class FrontRouterExampleI18NNews {
   /**
-   * @var SimpleXMLElement $article Individual article (for article page)
+   * @var SimpleXMLElement $article Individual article data (for article page)
    */
   private static $article;
 
@@ -103,7 +115,7 @@ class FrontRouterExampleI18NNews {
     self::$article = self::getArticle($year, $month, $day, $slug);
 
     if (self::$article) {
-      $title   = self::$article->title;
+      $title   = 'News article: ' . self::$article->title;
       $content = array(__CLASS__, 'articleAction');
     } else {
       $title   = 'Article not found';
@@ -117,8 +129,11 @@ class FrontRouterExampleI18NNews {
    * Load articles for main page
    */
   public static function indexAction() {
-    $articles = self::getArticles();
+    $articles = self::getArticles(array(
+      'lang' => self::getCurrentLang(),
+    ));
 
+    self::displayLangOptions();
     self::displayArticles($articles);
   }
 
@@ -128,9 +143,14 @@ class FrontRouterExampleI18NNews {
    * @param string $year
    */
   public static function yearAction($year) {
-    $articles = self::getArticles(array('year' => $year));
+    $articles = self::getArticles(array(
+      'year' => $year,
+      'lang' => self::getCurrentLang(),
+    ));
 
+    self::displayLangOptions();
     self::displayArticles($articles);
+    self::displayHomeLink();
   }
 
   /**
@@ -140,9 +160,15 @@ class FrontRouterExampleI18NNews {
    * @param string $month
    */
   public static function monthAction($year, $month) {
-    $articles = self::getArticles(array('year' => $year, 'month' => $month));
+    $articles = self::getArticles(array(
+      'year'  => $year,
+      'month' => $month,
+      'lang'  => self::getCurrentLang(),
+    ));
 
+    self::displayLangOptions();
     self::displayArticles($articles);
+    self::displayHomeLink();
   }
 
   /**
@@ -154,7 +180,9 @@ class FrontRouterExampleI18NNews {
    * @param string $slug
    */
   public static function articleAction($year, $month, $day, $slug) {
+    self::displayLangOptions($slug);
     self::displayArticle(self::$article);
+    self::displayHomeLink();
   }
 
   /**
@@ -171,9 +199,6 @@ class FrontRouterExampleI18NNews {
       <a href="/news/<?php echo $date['year']; ?>/<?php echo $date['month']; ?>/"><?php echo $date['month']; ?></a>
     </p>
     <?php echo $article->content; ?>
-    <p>
-      <a href="/news/">Back to news</a>
-    </p>
     <?php
   }
 
@@ -191,11 +216,12 @@ class FrontRouterExampleI18NNews {
       $year  = $date['year'];
       $month = $date['month'];
       $day   = $date['day'];
+      $slug  = strtok($article->slug, '_'); // Remove any language code from slug
       ?>
       <li>
         <h3>
           <strong>[<?php echo $year; ?>/<?php echo $month; ?>/<?php echo $day; ?>]</strong>
-          <a href="/news/<?php echo $date['year']; ?>/<?php echo $date['month']; ?>/<?php echo $date['day']; ?>/<?php echo $article->slug; ?>"><?php echo $article->title; ?></a>
+          <a href="/news/<?php echo $date['year']; ?>/<?php echo $date['month']; ?>/<?php echo $date['day']; ?>/<?php echo $slug; ?>.html"><?php echo $article->title; ?></a>
           </h3>
       </li>
       <?php
@@ -206,25 +232,35 @@ class FrontRouterExampleI18NNews {
   }
 
   /**
-   * Search for articles
+   * Search/query for articles
+   *
+   * @link http://mvlcek.bplaced.net/get-simple/i18nsearch for more I18N Search API details
    *
    * @param array $query {
    *   @param string $year
    *   @param string $month
+   *   @param string $words
+   *   @param array  $tags
+   *   @param string $lang
    * }
    *
    * @return array {
-   *   @var array results The search results
+   *   @var int   totalCount
+   *   @var int   first
+   *   @var array results
    * }
    */
   public static function getArticles($query = array()) {
     // Merge query defaults
     $query = array_merge(array(
-      'year' => '',
+      'words' => null,
+      'year'  => '',
       'month' => '',
+      'tags'  => array(),
+      'lang'  => return_i18n_default_language(),
     ), $query);
 
-    $tags  = array('_special_news');
+    $tags  = array_merge(array('_special_news'), $query['tags']);
 
     if ($query['year']) {
       $tags[] = '_cre_' . $query['year'];
@@ -234,11 +270,11 @@ class FrontRouterExampleI18NNews {
       $tags[] = '_cre_' . $query['year'] . $query['month'];
     }
 
-    $words = null;
+    $words = $query['words'];
     $first = 0;
-    $max   = 999;
+    $max   = 9999; // Shows all articles (no pagination)
     $order = 'created';
-    $lang  = null;
+    $lang  = $query['lang'];
 
     return return_i18n_search_results($tags, $words, $first, $max, $order, $lang);
   }
@@ -254,17 +290,17 @@ class FrontRouterExampleI18NNews {
    * @return SimpleXMLElement|bool Returns article if one on that day with that slug exists
    */
   public static function getArticle($year, $month, $day, $slug) {
-    $file = GSDATAPAGESPATH . $slug . '.xml';
+    $xml = @return_i18n_page_data($slug);
 
-    if (file_exists($file)) {
-      $xml = simplexml_load_file($file);
+    if ($xml) {
+      // Check that the date is correct
       $credate = (string) $xml->creDate;
       $timestamp = strtotime($credate);
       $compareDate = date('Y m d', $timestamp);
       $compareTo   = $year . ' ' . $month . ' ' . $day;
 
       if ($compareDate === $compareTo) {
-        return simplexml_load_file($file);
+        return $xml;
       } else {
         return false;
       }
@@ -293,5 +329,48 @@ class FrontRouterExampleI18NNews {
     $date   = explode(' ', $string);
 
     return array('year' => $date[0], 'month' => $date[1], 'day' => $date[2]);
+  }
+
+  /**
+   * Get the current language (either from setlang or lang URL parameter)
+   *
+   * @return string Langauge code, e.g. de
+   */
+  private static function getCurrentLang() {
+    if (isset($_GET['setlang'])) {
+      return $_GET['setlang'];
+    } elseif (isset($_GET['lang'])) {
+      return $_GET['lang'];
+    } elseif (isset($_COOKIE['language'])) {
+      return $_COOKIE['language'];
+    } else {
+      return return_i18n_default_language();
+    }
+  }
+
+  /**
+   * Print links to other language options for current page
+   *
+   * @param string $slug
+   */
+  private static function displayLangOptions($slug = null) {
+    $languages = return_i18n_available_languages($slug);
+    ?>
+    <p>
+      Languages:
+      <?php foreach ($languages as $lang): ?>
+      <span>
+        <a href="?setlang=<?php echo $lang?>"><?php echo $lang; ?></a>
+      </span>
+      <?php endforeach; ?>
+    </p>
+    <?php
+  }
+
+  /**
+   * Display link to news homepage
+   */
+  private static function displayHomeLink() {
+    ?><p><a href="/news/">Back to news home</a></p><?php
   }
 }

--- a/front_router/examples/news.php
+++ b/front_router/examples/news.php
@@ -43,6 +43,9 @@ add_action('front-route', 'addFrontRoute', array(
   'FrontRouterExampleI18NNews::articleRoute'
 ));
 
+// Add a sidebar link in the admin panel for quick access to the special pages
+add_action('pages-sidebar', 'createSideMenu', array('i18n_specialpages&pages&special=news', 'Manage News'));
+
 /**
  * @package FrontRouter
  * @subpackage ExampleI18NNews

--- a/front_router/examples/news.php
+++ b/front_router/examples/news.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Front Router I18N News Example
+ *
+ * This plugin assumes that you:
+ *  - Have I18N Special Pages installed
+ *  - Have I18N Search installed
+ *  - Have a special page called "News" created
+ */
+register_plugin(
+  basename(__FILE__, '.php'),
+  'Front Router I18N News Example',
+  '0.1.0',
+  'Lawrence Okoth-Odida',
+  'https://github.com/lokothodida',
+  'Front Router example plugin for a news module using I18N Special Pages and Search',
+  'plugins',
+  ''
+);
+
+// Register the routes
+// Main page
+add_action('front-route', 'addFrontRoute', array(
+  'news',
+  'FrontRouterExampleI18NNews::indexRoute'
+));
+
+// Articles by Year
+add_action('front-route', 'addFrontRoute', array(
+  'news/([0-9]{4})',
+  'FrontRouterExampleI18NNews::yearRoute'
+));
+
+// Articles by Month
+add_action('front-route', 'addFrontRoute', array(
+  'news/([0-9]{4})/([0-9]{2})',
+  'FrontRouterExampleI18NNews::monthRoute'
+));
+
+// Article
+add_action('front-route', 'addFrontRoute', array(
+  'news/([0-9]{4})/([0-9]{2})/([0-9]{2})/([a-z0-9-]+)',
+  'FrontRouterExampleI18NNews::articleRoute'
+));
+
+/**
+ * @package FrontRouter
+ * @subpackage ExampleI18NNews
+ */
+class FrontRouterExampleI18NNews {
+  /**
+   * @var SimpleXMLElement $article Individual article (for article page)
+   */
+  private static $article;
+
+  /**
+   * Load the index page
+   */
+  public static function indexRoute() {
+    return array(
+      'title'   => 'All News',
+      'content' => array(__CLASS__, 'indexAction')
+    );
+  }
+
+  /**
+   * Load the Year page
+   *
+   * @param string $year
+   */
+  public static function yearRoute($year) {
+    return array(
+      'title'   => 'News articles published in ' . $year,
+      'content' => array(__CLASS__, 'yearAction')
+    );
+  }
+
+  /**
+   * Load the Month page
+   *
+   * @param string $year
+   * @param string $month
+   */
+  public static function monthRoute($year, $month) {
+    return array(
+      'title'   => 'New articles published in ' . $year . ', ' . $month,
+      'content' => array(__CLASS__, 'monthAction')
+    );
+  }
+
+  /**
+   * Load the Article page
+   *
+   * @param string $year
+   * @param string $month
+   * @param string $day
+   * @param string $slug
+   */
+  public static function articleRoute($year, $month, $day, $slug) {
+    self::$article = self::getArticle($year, $month, $day, $slug);
+
+    if (self::$article) {
+      $title   = self::$article->title;
+      $content = array(__CLASS__, 'articleAction');
+    } else {
+      $title   = 'Article not found';
+      $content = 'Article ' . $slug . ' not found';
+    }
+
+    return array('title' => $title, 'content' => $content);
+  }
+
+  /**
+   * Load articles for main page
+   */
+  public static function indexAction() {
+    $articles = self::getArticles();
+
+    self::displayArticles($articles);
+  }
+
+  /**
+   * Load articles from a given year
+   *
+   * @param string $year
+   */
+  public static function yearAction($year) {
+    $articles = self::getArticles(array('year' => $year));
+
+    self::displayArticles($articles);
+  }
+
+  /**
+   * Load articles from a given month
+   *
+   * @param string $year
+   * @param string $month
+   */
+  public static function monthAction($year, $month) {
+    $articles = self::getArticles(array('year' => $year, 'month' => $month));
+
+    self::displayArticles($articles);
+  }
+
+  /**
+   * Load an individual article
+   *
+   * @param string $year
+   * @param string $month
+   * @param string $day
+   * @param string $slug
+   */
+  public static function articleAction($year, $month, $day, $slug) {
+    self::displayArticle(self::$article);
+  }
+
+  /**
+   * Display an individual article
+   *
+   * @param SimpleXMLElement $article
+   */
+  public static function displayArticle($article) {
+    $date = self::getArticleYearMonthDay($article->creDate);
+    ?>
+    <p>Posted by <?php echo $article->author; ?></p>
+    <p>Date:
+      <a href="/news/<?php echo $date['year']; ?>/"><?php echo $date['year']; ?></a>
+      <a href="/news/<?php echo $date['year']; ?>/<?php echo $date['month']; ?>/"><?php echo $date['month']; ?></a>
+    </p>
+    <?php echo $article->content; ?>
+    <p>
+      <a href="/news/">Back to news</a>
+    </p>
+    <?php
+  }
+
+  /**
+   * Display a list of articles
+   *
+   * @param array $articles
+   */
+  public static function displayArticles($articles) {
+    ?>
+    <ul>
+    <?php
+    foreach ($articles['results'] as $article) {
+      $date  = self::getArticleYearMonthDay($article->creDate);
+      $year  = $date['year'];
+      $month = $date['month'];
+      $day   = $date['day'];
+      ?>
+      <li>
+        <h3>
+          <strong>[<?php echo $year; ?>/<?php echo $month; ?>/<?php echo $day; ?>]</strong>
+          <a href="/news/<?php echo $date['year']; ?>/<?php echo $date['month']; ?>/<?php echo $date['day']; ?>/<?php echo $article->slug; ?>"><?php echo $article->title; ?></a>
+          </h3>
+      </li>
+      <?php
+    }
+    ?>
+    </ul>
+    <?php
+  }
+
+  /**
+   * Search for articles
+   *
+   * @param array $query {
+   *   @param string $year
+   *   @param string $month
+   * }
+   *
+   * @return array {
+   *   @var array results The search results
+   * }
+   */
+  public static function getArticles($query = array()) {
+    // Merge query defaults
+    $query = array_merge(array(
+      'year' => '',
+      'month' => '',
+    ), $query);
+
+    $tags  = array('_special_news');
+
+    if ($query['year']) {
+      $tags[] = '_cre_' . $query['year'];
+    }
+
+    if ($query['month']) {
+      $tags[] = '_cre_' . $query['year'] . $query['month'];
+    }
+
+    $words = null;
+    $first = 0;
+    $max   = 999;
+    $order = 'created';
+    $lang  = null;
+
+    return return_i18n_search_results($tags, $words, $first, $max, $order, $lang);
+  }
+
+  /**
+   * Get an individual article
+   *
+   * @param string $year
+   * @param string $month
+   * @param string $day
+   * @param string $slug
+   *
+   * @return SimpleXMLElement|bool Returns article if one on that day with that slug exists
+   */
+  public static function getArticle($year, $month, $day, $slug) {
+    $file = GSDATAPAGESPATH . $slug . '.xml';
+
+    if (file_exists($file)) {
+      $xml = simplexml_load_file($file);
+      $credate = (string) $xml->creDate;
+      $timestamp = strtotime($credate);
+      $compareDate = date('Y m d', $timestamp);
+      $compareTo   = $year . ' ' . $month . ' ' . $day;
+
+      if ($compareDate === $compareTo) {
+        return simplexml_load_file($file);
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Get the year, month and day from a timestamp
+   *
+   * @param string|long $timestamp
+   *
+   * @return array {
+   *   @var string year
+   *   @var string month
+   *   @var string day
+   * }
+   */
+  public static function getArticleYearMonthDay($timestamp) {
+    if (!is_long($timestamp)) {
+      $timestamp = strtotime((string) $timestamp);
+    }
+
+    $string = date('Y m d', $timestamp);
+    $date   = explode(' ', $string);
+
+    return array('year' => $date[0], 'month' => $date[1], 'day' => $date[2]);
+  }
+}

--- a/front_router/examples/news.php
+++ b/front_router/examples/news.php
@@ -98,7 +98,7 @@ class FrontRouterExampleI18NNews {
    */
   public static function monthRoute($year, $month) {
     return array(
-      'title'   => 'New articles published in ' . $year . ', ' . $month,
+      'title'   => 'News articles published in ' . $year . '/' . $month,
       'content' => array(__CLASS__, 'monthAction')
     );
   }
@@ -192,11 +192,14 @@ class FrontRouterExampleI18NNews {
    */
   public static function displayArticle($article) {
     $date = self::getArticleYearMonthDay($article->creDate);
+    $year  = $date['year'];
+    $month = $date['month'];
+    $day   = $date['day'];
     ?>
     <p>Posted by <?php echo $article->author; ?></p>
     <p>Date:
-      <a href="/news/<?php echo $date['year']; ?>/"><?php echo $date['year']; ?></a>
-      <a href="/news/<?php echo $date['year']; ?>/<?php echo $date['month']; ?>/"><?php echo $date['month']; ?></a>
+      <a href="/news/<?php echo $year; ?>/"><?php echo $year; ?></a>
+      <a href="/news/<?php echo $year; ?>/<?php echo $month; ?>/"><?php echo $month; ?></a>
     </p>
     <?php echo $article->content; ?>
     <?php
@@ -221,7 +224,7 @@ class FrontRouterExampleI18NNews {
       <li>
         <h3>
           <strong>[<?php echo $year; ?>/<?php echo $month; ?>/<?php echo $day; ?>]</strong>
-          <a href="/news/<?php echo $date['year']; ?>/<?php echo $date['month']; ?>/<?php echo $date['day']; ?>/<?php echo $slug; ?>.html"><?php echo $article->title; ?></a>
+          <a href="/news/<?php echo $year; ?>/<?php echo $month; ?>/<?php echo $day; ?>/<?php echo $slug; ?>.html"><?php echo $article->title; ?></a>
           </h3>
       </li>
       <?php


### PR DESCRIPTION
# Features
* Adds "i18n news" example plugin to repository
* News plugin allows news articles to be visited at `/news/` (home), `/news/yyyy/` (year), `/news/yyyy/mm/` (month) and `/news/yyyy/mm/dd/slug.html` (article)

# Todo
- [x] a21530b9e100683da79de240d436f06e45ae7b86 Make news I18N friendly (so setting the language with `setlang` or `lang` in the URL will pull the correct page data -- ~~currently it doesn't display the page with the example plugin's display settings)~~