### PR TITLE
Add Feature: RESTful API Endpoints

### DIFF
--- a/front_router.php
+++ b/front_router.php
@@ -32,6 +32,7 @@ function register_plugin_front_router() {
   require_once(FRONTROUTER_PHPPATH . 'url.class.php');
   require_once(FRONTROUTER_PHPPATH . 'admin.class.php');
   require_once(FRONTROUTER_PHPPATH . 'data.class.php');
+  require_once(FRONTROUTER_PHPPATH . 'rest.class.php');
   require_once(FRONTROUTER_PHPPATH . 'polyfill.php');
   require_once(FRONTROUTER_PHPPATH . 'api.php');
 

--- a/front_router/php/plugin.class.php
+++ b/front_router/php/plugin.class.php
@@ -68,7 +68,7 @@ class FrontRouter {
 
       // Merge in the data
       foreach ($data as $prop => $value) {
-        $data_index->{$prop} = $value;
+        $data_index->{$prop} = (string) $value;
       }
     }
 

--- a/front_router/php/plugin.class.php
+++ b/front_router/php/plugin.class.php
@@ -53,7 +53,7 @@ class FrontRouter {
     $data = FrontRouterRouter::executeFront($url);
 
     // Set data from the router's action
-    if ($data && @$data->type) {
+    if ($data && property_exists($data, 'type') && $data->type === 'json') {
       // RESTful service
       header('Content-Type: application/json');
       exit(json_encode($data->content));

--- a/front_router/php/plugin.class.php
+++ b/front_router/php/plugin.class.php
@@ -53,7 +53,11 @@ class FrontRouter {
     $data = FrontRouterRouter::executeFront($url);
 
     // Set data from the router's action
-    if ($data) {
+    if ($data && @$data->type) {
+      // RESTful service
+      header('Content-Type: application/json');
+      exit(json_encode($data->content));
+    } elseif ($data) {
       // Ensure $data_index has a default object
       $data_index = $data_index ? $data_index : getPageObject();
 

--- a/front_router/php/plugin.class.php
+++ b/front_router/php/plugin.class.php
@@ -54,10 +54,15 @@ class FrontRouter {
 
     // Set data from the router's action
     if ($data && property_exists($data, 'type') && $data->type === 'json') {
-      // RESTful service
+      // RESTful JSON service
       header('Content-Type: application/json');
-      exit(json_encode($data->content));
+      exit(FrontRouterRest::arrayToJSONString($data->content));
+    } elseif ($data && property_exists($data, 'type') && $data->type === 'xml') {
+      // RESTful XML service
+      header('Content-Type: application/xml');
+      exit(FrontRouterREST::arrayToXMLString($data->content));
     } elseif ($data) {
+      // Front routed page
       // Ensure $data_index has a default object
       $data_index = $data_index ? $data_index : getPageObject();
 

--- a/front_router/php/rest.class.php
+++ b/front_router/php/rest.class.php
@@ -1,0 +1,51 @@
+<?php
+
+class FrontRouterREST {
+  /**
+   * Convert an array data to a valid JSON string
+   */
+  public static function arrayToJSONString($array = array()) {
+    return json_encode($array);
+  }
+
+  /**
+   * Convert an array data to a valid XML string
+   *
+   */
+  public static function arrayToXMLString($array = array()) {
+    $xml = new SimpleXMLElement('<?xml version="1.0"?><data></data>');
+
+    // function call to convert array to xml
+    self::arrayToXML($array, $xml);
+
+    //saving generated xml file;
+    return $xml->asXML();
+  }
+
+  /**
+   * http://stackoverflow.com/a/5965940
+   */
+  private static function arrayToXML($data = array(), &$xml_data) {
+    foreach ($data as $key => $value) {
+      if (is_numeric($key)) {
+        $key = 'item'.$key; //dealing with <0/>..<n/> issues
+      }
+
+      if ($key === '@attributes' && is_array($value)) {
+        // Attributes
+        foreach ($value as $attr => $val) {
+          $xml_data->addAttribute("$attr", htmlspecialchars("$val"));
+        }
+      } elseif (is_array($value)) {
+        // Multiple nodes with the same name
+        foreach ($value as $k => $v) {
+          $subnode = $xml_data->addChild($key);
+          self::arrayToXML($v, $subnode);
+        }
+      } else {
+        // Individual node
+        $xml_data->addChild("$key", htmlspecialchars("$value"));
+      }
+    }
+  }
+}

--- a/front_router/php/rest.class.php
+++ b/front_router/php/rest.class.php
@@ -35,8 +35,8 @@ class FrontRouterREST {
    * @param SimpleXMLElement $xml_data
    */
   private static function arrayToXML($data = array(), &$xml_data) {
-    if (!is_array($data)) {
-      // No more arrays to iterate over - just stick the data into the node
+    if (!is_array($data) && !is_object($data)) {
+      // No more arrays/objects to iterate over - just stick the data into the node
       $xml_data[0] = "$data";
       return;
     }

--- a/front_router/php/rest.class.php
+++ b/front_router/php/rest.class.php
@@ -3,6 +3,9 @@
 class FrontRouterREST {
   /**
    * Convert an array data to a valid JSON string
+   *
+   * @param array $array
+   * @return string
    */
   public static function arrayToJSONString($array = array()) {
     return json_encode($array);
@@ -11,6 +14,8 @@ class FrontRouterREST {
   /**
    * Convert an array data to a valid XML string
    *
+   * @param array $array
+   * @return string
    */
   public static function arrayToXMLString($array = array()) {
     $xml = new SimpleXMLElement('<?xml version="1.0"?><data></data>');
@@ -23,12 +28,16 @@ class FrontRouterREST {
   }
 
   /**
-   * http://stackoverflow.com/a/5965940
+   * Convert an array to XML
+   * Edited from http://stackoverflow.com/a/5965940
+   *
+   * @param array $data
+   * @param SimpleXMLElement $xml_data
    */
   private static function arrayToXML($data = array(), &$xml_data) {
     foreach ($data as $key => $value) {
       if (is_numeric($key)) {
-        $key = 'item'.$key; //dealing with <0/>..<n/> issues
+        $key = 'item' . $key; //dealing with <0/>..<n/> issues
       }
 
       if ($key === '@attributes' && is_array($value)) {

--- a/front_router/php/rest.class.php
+++ b/front_router/php/rest.class.php
@@ -35,6 +35,13 @@ class FrontRouterREST {
    * @param SimpleXMLElement $xml_data
    */
   private static function arrayToXML($data = array(), &$xml_data) {
+    if (!is_array($data)) {
+      // No more arrays to iterate over - just stick the data into the node
+      $xml_data[0] = "$data";
+      return;
+    }
+
+    // Iterate through each data key=>value pair
     foreach ($data as $key => $value) {
       if (is_numeric($key)) {
         $key = 'item' . $key; // dealing with <0/>..<n/> issues

--- a/front_router/php/rest.class.php
+++ b/front_router/php/rest.class.php
@@ -18,18 +18,18 @@ class FrontRouterREST {
    * @return string
    */
   public static function arrayToXMLString($array = array()) {
-    $xml = new SimpleXMLElement('<?xml version="1.0"?><data></data>');
+    $xml = new SimpleXMLElement('<?xml version="1.0" encoding="UTF-8"?><data></data>');
 
-    // function call to convert array to xml
+    // Convert data to XML
     self::arrayToXML($array, $xml);
 
-    //saving generated xml file;
+    // Generate XML
     return $xml->asXML();
   }
 
   /**
    * Convert an array to XML
-   * Edited from http://stackoverflow.com/a/5965940
+   * @link http://stackoverflow.com/a/5965940
    *
    * @param array $data
    * @param SimpleXMLElement $xml_data
@@ -37,7 +37,7 @@ class FrontRouterREST {
   private static function arrayToXML($data = array(), &$xml_data) {
     foreach ($data as $key => $value) {
       if (is_numeric($key)) {
-        $key = 'item' . $key; //dealing with <0/>..<n/> issues
+        $key = 'item' . $key; // dealing with <0/>..<n/> issues
       }
 
       if ($key === '@attributes' && is_array($value)) {


### PR DESCRIPTION
# Features
* Users can build RESTful APIs using data from their GetSimple installation #8 
* Endpoints can be formatted in XML or JSON
* URLs are matched using the same front router interface
* Instead of `echo`ing the data, it is `return`ed and the result transformed into the specified format 
* Extra properties are added to the `content` callback's data:
  * `type` - output format (`xml/json`) (**required** for route to be treated as a REST API)
  * `method` - request method (leave empty for `any`) - `get/post/put/delete`

# Example
## Route
```
api/v1/users/([a-z0-9-]+)
```

## Action
```php
<?php

return array(
  'type'    => 'json',    // Outputs a JSON
  'method'  => 'get',     // Only matches on GET requests
  'content' => function($user_id) {
    $result = array('version' => '1.0');

    // Imagine there are functions user_exists() and get_user_profile() to check for
    // profiles and get existing profiles:
    if (user_exists($user_id)) {
      $result['user'] = get_user_profile($user_id);
      $result['success'] = true;
    } else {
      $result['success'] = false;
    }

    // Result is automatically encoded to JSON by the plugin
    return $result;
  }
);
```

# Todo
* [x] Draft documentation for the `type` and `method` properties (e.g. there are certain formatting details users will need to know when using `xml` as their type)
* [ ] Produce example plugins of RESTful APIs